### PR TITLE
Add explicit extensions to import statements

### DIFF
--- a/Progress.js
+++ b/Progress.js
@@ -1,4 +1,4 @@
-import speedometer from './speedometer';
+import speedometer from './speedometer.js';
 
 export default class Progress {
   constructor(length, emitDelay = 1000) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import Progress from './Progress';
+import Progress from './Progress.js';
 
 export function isFetchProgressSupported() {
   return (


### PR DESCRIPTION
Needed to prevent errors in browsers:

> Browsers, Deno, and Node.js do not natively support importing files without extensions from JavaScript modules.

— https://biomejs.dev/linter/rules/use-import-extensions/